### PR TITLE
Fix rlang::UQS() warning

### DIFF
--- a/R/polypoly-package.R
+++ b/R/polypoly-package.R
@@ -160,7 +160,7 @@ poly_add_columns <- function(.data, .col, degree = 1, prefix = NULL,
   merged[["...rowid"]] <- NULL
 
   cols_to_add <- as.list(merged)[names]
-  tibble::add_column(.data, rlang::UQS(cols_to_add))
+  tibble::add_column(.data, !!!(cols_to_add))
 }
 
 

--- a/R/polypoly-package.R
+++ b/R/polypoly-package.R
@@ -160,7 +160,7 @@ poly_add_columns <- function(.data, .col, degree = 1, prefix = NULL,
   merged[["...rowid"]] <- NULL
 
   cols_to_add <- as.list(merged)[names]
-  tibble::add_column(.data, !!!(cols_to_add))
+  tibble::add_column(.data, !!! cols_to_add)
 }
 
 


### PR DESCRIPTION
Fixes #1

```
── R CMD check results ─────────────────────────────────────────────────────────── polypoly 0.0.2.9000 ────
Duration: 27s

> checking for unstated dependencies in examples ... OK
   WARNING
  ‘qpdf’ is needed for checks on size reduction of PDFs

0 errors ✓ | 1 warning x | 0 notes ✓
Error: R CMD check found WARNINGs
Execution halted

Exited with status 1.
```